### PR TITLE
Update to `zeit.cms >= 2.90`.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 Changes
 =======
 
-2.14.1 (unreleased)
+2.15.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Update to `zeit.cms >= 2.90`.
 
 
 2.14.0 (2016-06-27)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ NEWS = open(os.path.join(here, 'CHANGES.txt')).read()
 
 setup(
     name='zeit.edit',
-    version='2.14.1.dev0',
+    version='2.15.0.dev0',
     description="Vivi Editor",
     long_description=README + '\n\n' + NEWS,
     keywords='',
@@ -36,7 +36,7 @@ setup(
         'setuptools',
         'transaction',
         'xml_compare',
-        'zeit.cms>=2.64.0.dev0',
+        'zeit.cms>=2.90.0.dev0',
         'zeit.connector',
         'zeit.find>=2.2.dev.0',
         'zope.app.appsetup',

--- a/src/zeit/edit/tests/test_block.py
+++ b/src/zeit/edit/tests/test_block.py
@@ -1,4 +1,4 @@
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import lxml.objectify
 import mock
 import persistent.interfaces
@@ -23,10 +23,10 @@ class ElementUniqueIdTest(zeit.edit.testing.FunctionalTestCase):
         self.block = zeit.edit.tests.fixture.Block(
             self.container, xml.block)
         # Fake traversal ability.
-        TestContentType.__getitem__ = lambda s, key: self.container
+        ExampleContentType.__getitem__ = lambda s, key: self.container
 
     def tearDown(self):
-        del TestContentType.__getitem__
+        del ExampleContentType.__getitem__
         super(ElementUniqueIdTest, self).tearDown()
 
     def test_block_ids_are_composed_of_parent_ids(self):

--- a/src/zeit/edit/tests/test_meta.py
+++ b/src/zeit/edit/tests/test_meta.py
@@ -7,23 +7,25 @@ import zope.component
 import zope.interface
 
 
-class ITestElement(zeit.edit.interfaces.IElement):
+class IExampleElement(zeit.edit.interfaces.IElement):
     pass
 
 
-class TestElement(zeit.edit.block.SimpleElement):
+class ExampleElement(zeit.edit.block.SimpleElement):
 
     area = zope.interface.Interface
     type = 'testelement'
-    grokcore.component.implements(ITestElement)
+    grokcore.component.implements(IExampleElement)
 
 
 class TestSimpleElementGrokker(zeit.edit.testing.FunctionalTestCase):
 
     def test_grokking_test_element_should_register_multiadapter(self):
         import lxml.objectify
-        grokcore.component.testing.grok_component('TestElement', TestElement)
+        grokcore.component.testing.grok_component(
+            'ExampleElement', ExampleElement)
         tree = lxml.objectify.E.tree()
-        element = zope.component.getMultiAdapter(
-            (object(), tree), zeit.edit.interfaces.IElement,
-            name='testelement')
+        with self.assertNothingRaised():
+            zope.component.getMultiAdapter(
+                (object(), tree), zeit.edit.interfaces.IElement,
+                name='testelement')

--- a/src/zeit/edit/tests/test_rule.py
+++ b/src/zeit/edit/tests/test_rule.py
@@ -275,13 +275,13 @@ class RecursiveValidatorTest(unittest.TestCase):
         self.assertEqual(ERROR, validator.status)
 
 
-@zope.component.adapter(zeit.cms.testcontenttype.interfaces.ITestContentType)
+@zope.component.adapter(zeit.cms.testcontenttype.interfaces.IExampleContentType)
 @zope.interface.implementer(zeit.cms.workflow.interfaces.IPublishInfo)
 def validating_workflow_for_testcontent(context):
     return zeit.edit.rule.ValidatingWorkflow(context)
 
 
-@zope.component.adapter(zeit.cms.testcontenttype.interfaces.ITestContentType)
+@zope.component.adapter(zeit.cms.testcontenttype.interfaces.IExampleContentType)
 @zope.interface.implementer(zeit.edit.interfaces.IValidator)
 def validator_for_testcontent(context):
     validator = mock.Mock(
@@ -305,16 +305,16 @@ class ValidatingWorkflowTest(unittest.TestCase):
 
     def test_validating_workflow_cannot_publish_when_validation_failed(self):
         workflow = zeit.cms.workflow.interfaces.IPublishInfo(
-            zeit.cms.testcontenttype.testcontenttype.TestContentType())
+            zeit.cms.testcontenttype.testcontenttype.ExampleContentType())
         self.assertEqual(CAN_PUBLISH_ERROR, workflow.can_publish())
 
     def test_validating_workflow_provides_error_messages_for_publish_info(
             self):
-        from zeit.cms.testcontenttype.testcontenttype import TestContentType
+        from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
         import zeit.workflow.browser.publish
 
         view = zeit.workflow.browser.publish.Publish()
-        view.context = TestContentType()
+        view.context = ExampleContentType()
         view.can_publish()
         self.assertEqual(
             'Mock Validator Error Message', view.error_messages[1])


### PR DESCRIPTION
Plus some py.test compat changes. Class whose name starts with `Test` having a constructor leads to a warning in py.test as it cannot be collected as a test case class.
