### PR TITLE
MAINT: Replace complicated register_element_factory with simpler grokked baseclass.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,14 @@
 Changes
 =======
 
-2.16.3 (unreleased)
+2.17.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- MAINT: Replace complicated register_element_factory with simpler
+  grokked baseclass.
+  The former could register one element for multiple containers in one go,
+  but we don't use this anymore since the 2015 relaunch (all areas in
+  z.c.cp are now the same).
 
 
 2.16.2 (2017-10-20)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 setup(
     name='zeit.edit',
-    version='2.16.3.dev0',
+    version='2.17.0.dev0',
     description="Vivi Editor",
     long_description='',
     keywords='',

--- a/src/zeit/edit/meta.py
+++ b/src/zeit/edit/meta.py
@@ -1,4 +1,5 @@
 import gocept.lxml.interfaces
+import grokcore.component
 import martian
 import zeit.edit.block
 import zeit.edit.interfaces
@@ -51,5 +52,21 @@ class SimpleElementGrokker(martian.ClassGrokker):
             discriminator=('adapter', for_, provides, context.type),
             callable=zope.component.provideAdapter,
             args=(context, for_, provides, context.type),
+        )
+        return True
+
+
+class ElementFactoryGrokker(martian.ClassGrokker):
+
+    martian.component(zeit.edit.block.ElementFactory)
+    martian.directive(grokcore.component.context)
+
+    def execute(self, factory, config, context, **kw):
+        name = factory.element_type = factory.produces.type
+        provides = list(zope.interface.implementedBy(factory))[0]
+        config.action(
+            discriminator=('adapter', context, provides, name),
+            callable=zope.component.provideAdapter,
+            args=(factory, (context,), provides, name),
         )
         return True

--- a/src/zeit/edit/tests/fixture.py
+++ b/src/zeit/edit/tests/fixture.py
@@ -31,9 +31,15 @@ class Container(zeit.edit.container.TypeOnAttributeContainer,
     grok.adapts(
         IContainer,
         gocept.lxml.interfaces.IObjectified)
-    grok.name('container')
+    type = 'container'
+    grok.name(type)
 
-zeit.edit.block.register_element_factory(IContainer, 'container', 'Container')
+
+class ContainerFactory(zeit.edit.block.TypeOnAttributeElementFactory):
+
+    grok.context(IContainer)
+    produces = Container
+    title = 'Container'
 
 
 class Block(zeit.edit.block.SimpleElement, grok.MultiAdapter):
@@ -43,4 +49,9 @@ class Block(zeit.edit.block.SimpleElement, grok.MultiAdapter):
     grok.provides(IBlock)
     type = 'block'
 
-zeit.edit.block.register_element_factory(IContainer, 'block', 'Block')
+
+class BlockFactory(zeit.edit.block.TypeOnAttributeElementFactory):
+
+    grok.context(IContainer)
+    produces = Block
+    title = 'Block'


### PR DESCRIPTION
The former could register one element for multiple containers in one go, but we don't use this anymore since the 2015 relaunch (all areas in z.c.cp are now the same).

So we extracted the simple mechanics from z.c.article here, and now use it in z.c.cp and zeit.newsletter